### PR TITLE
Add access to retrieve current project from peering acceptor role

### DIFF
--- a/modules/cloudaccess/wf_peering_acceptor.tf
+++ b/modules/cloudaccess/wf_peering_acceptor.tf
@@ -31,6 +31,7 @@ resource "google_project_iam_custom_role" "peeringacceptor" {
     "compute.networks.removePeering",
     "compute.globalOperations.list",
     "compute.networks.addPeering",
+    "resourcemanager.projects.get",
   ]
 }
 

--- a/modules/cloudaccess/wf_peering_acceptor.tf
+++ b/modules/cloudaccess/wf_peering_acceptor.tf
@@ -31,6 +31,7 @@ resource "google_project_iam_custom_role" "peeringacceptor" {
     "compute.networks.removePeering",
     "compute.globalOperations.list",
     "compute.networks.addPeering",
+    "resourcemanager.projects.list",
     "resourcemanager.projects.get",
   ]
 }

--- a/modules/cloudaccess/wf_peering_acceptor.tf
+++ b/modules/cloudaccess/wf_peering_acceptor.tf
@@ -31,7 +31,6 @@ resource "google_project_iam_custom_role" "peeringacceptor" {
     "compute.networks.removePeering",
     "compute.globalOperations.list",
     "compute.networks.addPeering",
-    "resourcemanager.projects.list",
     "resourcemanager.projects.get",
   ]
 }


### PR DESCRIPTION
Wayfinder uses this to detect it is in the correct project when assessing role validity.